### PR TITLE
refactor: do not render header if named slots are not used

### DIFF
--- a/v-table.vue
+++ b/v-table.vue
@@ -293,7 +293,7 @@ app.component('vTable', {
 <template>
 	<div v-bind="$attrs" class="v-table" :class="layout == 'card' && 'card'">
 		<!-- Header {{{ -->
-		<div :class="layout == 'card' && 'card-header'">
+		<div v-if="layout != 'card' || $slots['table-header'] || $slots['table-header-left'] || $slots['table-header-center'] || $slots['table-header-right']" :class="layout == 'card' && 'card-header'">
 			<slot name="table-header">
 				<div class="v-table-header">
 					<slot name="table-header-left"/>


### PR DESCRIPTION
Currently if no table-header content is provided, it will still render an empty element for the `.card-header`:

```html
<div class="card">
	<div class="card-header">  </div>
	<div class="card-body">
		…
	</div>
	…
</div>
```

Normally this shouldn't be a problem, the unstyled empty element can just be there because it most likely would have a height of 0, no padding, no borders, etc. and wouldn't be visible. However Bootstrap will add padding to `.card-header` — and use the existence of this element in the markup to determine whether or not to apply top corner border radii to the card header or card body. Not to mention the application of other styles dependent on whether or not card header is present.

So due to this, we should not render the card header element at all (when card layout is being used):

```html
<div class="card">
	<div class="card-body">
		…
	</div>
	…
</div>
```